### PR TITLE
docs(casebook): ecosystem audit edition — 33 verified findings across 71 repos

### DIFF
--- a/campaigns/measurement-casebook.md
+++ b/campaigns/measurement-casebook.md
@@ -4,6 +4,74 @@ These are engineering contributions and counterexamples, not product adoption
 claims or endorsements. Each case links to its public source and states what
 the evidence does not establish.
 
+## Ecosystem audit: 33 verified usage-accounting findings (2026-09-06/07)
+
+Over two days we deep-read 71 repositories across the Claude/Codex usage-tool
+long tail, LLM observability platforms, eval frameworks, gateways, and
+upstream pricing-data sources, and filed 33 evidence-backed findings — every
+one pinned to a commit SHA, verified by a runnable reproduction or a quoted
+static argument, and checked against the target's issue history for
+duplicates. The method is the product demo: the same hazard taxonomy and
+synthetic-fixture discipline that drive the AgentMeasure conformance pack
+were applied to other people's code.
+
+What this establishes: these specific defects exist at these commits, and the
+audit method finds real, quantified accounting errors that the projects' own
+test suites missed. What it does not establish: that any of these projects
+endorses or uses AgentMeasure, that the maintainers will accept the fixes, or
+that every tool in the space has these defects (the majority of audited
+repos — including promptfoo, Portkey's model data, and tokscale — passed
+clean).
+
+The hazard classes (with the number of confirmed instances found):
+
+- **Per-block re-summation** — Claude Code writes one JSONL line per content
+  block, each carrying the same `message.id` and the same `message.usage`;
+  summing per line multiplies usage by block count. 9 confirmed instances,
+  2×–3× inflation (e.g. [tokendash #37](https://github.com/zhangferry/tokendash/pull/37),
+  [agent-bill #1](https://github.com/yange0793-dot/agent-bill/pull/1),
+  [ccem #12](https://github.com/Genuifx/ccem/issues/12),
+  [samewrite #1](https://github.com/ipeterpetrus/samewrite/issues/1)).
+- **Re-emitted event re-summation** — Codex re-emits `token_count` events with
+  identical totals after compaction/settings/rate-limit refreshes; naive
+  per-event accumulation double-counts them. Verified on real corpora and
+  fixed in 4 tools (e.g. [tokenscope #6](https://github.com/stealthsrc/tokenscope/pull/6),
+  [token-vision #1](https://github.com/extrei/token-vision/issues/1),
+  [coding-agent-usage-tracker #1](https://github.com/avihut/coding-agent-usage-tracker/pull/1)).
+- **Cache pricing semantics** — Anthropic `input_tokens` excludes cache while
+  OpenAI's includes it; conflating the two clamps input to zero or double-
+  charges cache. 1h-TTL writes are 2× input, not 1.25×
+  ([claude-hud #758](https://github.com/jarrodwatts/claude-hud/pull/758),
+  [tokenguard analysis](https://github.com/QQSHI13/tokenguard) — repo
+  archived before filing, [one-api-pro #13](https://github.com/modelbus/one-api-pro/issues/13)).
+- **Pricing-table drift** — embedded price tables diverging from published
+  rates, 1.2×–3× per model ([switchXprovider #1](https://github.com/shaheer-00/switchXprovider/pull/1),
+  [Tokdash #75](https://github.com/JingbiaoMei/Tokdash/pull/75),
+  [iris-eval #478](https://github.com/iris-eval/mcp-server/pull/478),
+  [litellm #40360](https://github.com/BerriAI/litellm/issues/40360) — in
+  the industry's pricing source of record).
+- **Loss on resume/fork** — sessions re-opened or forked lose or duplicate
+  their history ([ai-usage-inspector #1](https://github.com/Kud0o/ai-usage-inspector/issues/1),
+  [swarm #145](https://github.com/ra3orblade/swarm/issues/145)).
+
+**Accepted so far: 1.** The swarm maintainer merged the fix in
+[swarm PR #146](https://github.com/ra3orblade/swarm/pull/146), crediting the
+report: *"reported and diagnosed by @roy-tong, who also supplied the patch
+this follows."* Everything else is open and unreviewed at the time of
+writing; several maintainers approved CI runs on our PRs
+([claude-hud](https://github.com/jarrodwatts/claude-hud/pull/757),
+[Claude-Code-Agent-Monitor
+#328](https://github.com/hoangsonww/Claude-Code-Agent-Monitor/pull/328)).
+Reproductions use fully synthetic fixtures derived from this project's
+reference corpus — no private logs were shared anywhere.
+
+The full audit log, per-finding evidence, and the honest no-gap list (most
+audited projects passed) are maintained internally; the public trail is the
+linked PRs and issues above. If you want the fixture shapes that expose these
+classes in your own tool, they are in the
+[conformance pack](../conformance/pack/README.md) — no AgentMeasure runtime
+required.
+
 ## Exposing reasoning tokens without adding them twice
 
 [OpenLIT PR #1476](https://github.com/openlit/openlit/pull/1476) was merged on


### PR DESCRIPTION
## What

Adds the ecosystem-audit edition to the measurement casebook: over 2026-09-06/07 we deep-read 71 repositories (usage tools, observability platforms, eval frameworks, gateways, pricing sources) and filed 33 evidence-backed usage-accounting findings. The new section summarizes the five hazard classes with confirmed-instance counts and links every claim to the public PR/issue.

## Honesty rules kept

- States explicitly what the audit does **not** establish (no adoption, no endorsement, most audited repos passed clean — promptfoo, Portkey model data, tokscale are named as passing).
- One accepted artifact to date (swarm #145 → PR #146, maintainer-credited); all other items listed as open/unreviewed.
- No private logs; all reproductions are synthetic fixtures from the conformance pack.

## Why this belongs in the repo

The casebook is the product demo: the same taxonomy and fixture discipline that drive the conformance pack found quantified, verified defects that the targets' own test suites missed. Ends with a pointer to the fixture shapes for tool authors — no AgentMeasure runtime required.
